### PR TITLE
Use subprojects instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project (LibEBC)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,5 @@
+project(lib)
+
 include(CheckLibraryExists)
 
 # LibXml2 Dependency
@@ -41,8 +43,8 @@ endif()
 
 # Configure header
 configure_file (
-  "${PROJECT_SOURCE_DIR}/lib/include/ebc/Config.h.in"
-  "${PROJECT_BINARY_DIR}/ebc/Config.h")
+  "${lib_SOURCE_DIR}/include/ebc/Config.h.in"
+  "${lib_BINARY_DIR}/ebc/Config.h")
 
 # UUID
 if(UNIX AND NOT APPLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+project (test)
+
 # LibXml2 Dependency
 find_package(LibXml2 REQUIRED)
 include_directories(${LIBXML2_INCLUDE_DIR})

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,11 +1,12 @@
+project (tool)
 add_subdirectory(vendor)
 
 # Configure
 configure_file (
-  "${PROJECT_SOURCE_DIR}/tool/ebcutil.cpp"
-  "${PROJECT_BINARY_DIR}/tool/ebcutil.cpp")
+  "${tool_SOURCE_DIR}/ebcutil.cpp"
+  "${tool_BINARY_DIR}/ebcutil.cpp")
 
-add_executable(ebcutil ${PROJECT_BINARY_DIR}/tool/ebcutil.cpp)
+add_executable(ebcutil ${tool_BINARY_DIR}/ebcutil.cpp)
 target_link_libraries(ebcutil ebc tclap rang)
 
 set_property(TARGET ebcutil PROPERTY CXX_STANDARD 14)


### PR DESCRIPTION
Cmake 3.5 (https://github.com/ttroy50/cmake-examples/tree/master/02-sub-projects/A-basic) uses subprojects.  This makes it easier to compile by using the individual project dirs.